### PR TITLE
17 set alias tf = terraform

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,12 +1,14 @@
 tasks:
   - name: terraform
     before: |
+      source ./bin/add_tf_alias
       source ./bin/install_terraform_cli
       source ./bin/generate_tfrc_credentials
   - name: aws-cli
     env:
       AWS_CLI_AUTO_PROMPT: on-partial
     before: |
+      source ./bin/add_tf_alias
       source ./bin/install_aws_cli
 vscode:
   extensions:

--- a/bin/add_tf_alias
+++ b/bin/add_tf_alias
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+alias_line='alias tf="terraform"'
+
+# Check if the alias already exists in .bash_profile
+if ! grep -qF "$alias_line" ~/.bash_profile; then
+  echo "$alias_line" >> ~/.bash_profile
+  echo "Alias 'tf' for 'terraform' added to .bash_profile"
+else
+  echo "Alias 'tf' for 'terraform' already exists in .bash_profile"
+fi

--- a/bin/add_tf_alias
+++ b/bin/add_tf_alias
@@ -9,3 +9,5 @@ if ! grep -qF "$alias_line" ~/.bash_profile; then
 else
   echo "Alias 'tf' for 'terraform' already exists in .bash_profile"
 fi
+# Optional: source the .bash_profile to make the alias available immediately
+source ~/.bash_profile


### PR DESCRIPTION

-[x] We need to use tf as alias in ~/.bash_profile, which help us just need to type tf instead of terraform command in bash.

